### PR TITLE
Add BASE_URL environment configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt update
 RUN apt install -y curl htop
 RUN apt install -y nginx
 RUN apt install -y libdbi-perl libdbd-pg-perl
+RUN apt install -y gettext
 
 # move build files to container
 COPY service/build /opt/service

--- a/docker/production/entrypoint.sh
+++ b/docker/production/entrypoint.sh
@@ -9,6 +9,13 @@ nginx -v
 export GIN_MODE=release
 /opt/service/ivory &
 
+# insert base url
+envsubst '\$BASE_URL' < /etc/nginx/nginx.conf > "/etc/nginx/nginx.conf.tmp" && mv "/etc/nginx/nginx.conf.tmp" "/etc/nginx/nginx.conf"
+if [ -n "${BASE_URL}" ]; then
+    sed -i "s/location \//location \\${BASE_URL}/g" /etc/nginx/nginx.conf
+    sed -i "s/api/\/api/g" /etc/nginx/nginx.conf
+fi
+
 # run nginx server
 /usr/sbin/nginx &
 

--- a/docker/production/nginx.conf
+++ b/docker/production/nginx.conf
@@ -10,12 +10,13 @@ http {
         listen 80;
 
         location / {
-            root /opt/web;
+            alias /opt/web/;
             index index.html;
             try_files $uri $uri/ =404;
         }
 
         location /api {
+            rewrite ${BASE_URL}(.*) $1 break;
             proxy_set_header Connection '';
             proxy_pass http://localhost:8080;
             # we need this for events-stream we don't want to gzip or cache any data

--- a/web/src/app/api.ts
+++ b/web/src/app/api.ts
@@ -21,7 +21,7 @@ import {AppConfig, AppInfo, Login, Response, Sidecar} from "../type/general";
 import {Bloat, BloatRequest} from "../type/bloat";
 import {Cluster, ClusterAuto, ClusterMap} from "../type/cluster";
 
-export const api = axios.create({baseURL: '/api'})
+export const api = axios.create({baseURL: './api'})
 
 export const GeneralApi = {
     info: {


### PR DESCRIPTION
Make API URL also relative and insert BASE_URL into Nginx configuration so that it can fully work with proxies.

One can create Ivory container by a command like `docker run -d -e BASE_URL="/ivory" -p 80:80 --restart unless-stopped aelsergeev/ivory` to make it work under `/ivory` or any other give url. It can also still works even if the variable hasn't been assigned, but **once it's assigned, it must start with a slash '/'.**

Notice that `nginx.conf` has been changed to rewrite the api request path, which causes **it now can't be used directly without `envsubst`**.

