### PR TITLE
fix: sslmode=disable fallback when tlsConfig is nil

### DIFF
--- a/service/src/clients/database/postgres/client.go
+++ b/service/src/clients/database/postgres/client.go
@@ -282,6 +282,10 @@ func (s *Client) getConnection(ctx database.Context) (*pgx.Conn, string, error) 
 		// NOTE: verify-ca was chosen because it potentially can protect from machine-in-the-middle attack if
 		// it has the right CA policy. More info can be found here https://www.postgresql.org/docs/16/libpq-ssl.html#LIBPQ-SSL-PROTECTION
 		connUrl += "?sslmode=verify-ca"
+	} else {
+		// NOTE: explicitly set sslmode=disable so pgx does not default to sslmode=require.
+		// This allows connections to PostgreSQL servers without SSL/TLS enabled.
+		connUrl += "?sslmode=disable"
 	}
 
 	conConfig, errConfig := pgx.ParseConfig(connUrl)


### PR DESCRIPTION
## Summary
Adds an explicit `sslmode=disable` parameter when no TLS	config is set, preventing the pgx driver from defaulting to `sslmode=require` and failing against PostgreSQL servers without SSL enabled.

## Changes
**service/src/clients/database/postgres/client.go**

When `tlsConfig == nil` (no client certificates configured), the pgx driver would default to `sslmode=require`, causing connections to PostgreSQL servers without SSL to fail with:
```
tls error: server refused TLS connection
```

This fix explicitly adds `?sslmode=disable` in that case, allowing plain connections.

> NOTE: If users later configure mutual TLS certificates (client CA/cert/key), the connection upgrades to `sslmode=verify-ca` — so explicit TLS requirement is preserved when certs are provided.

## Testing
- `go build ./...` passes ✓
- No behavioral change for TLS-configured connections
- Requires manual testing against PostgreSQL without SSL enabled

Closes #725